### PR TITLE
Hotfix 20180104

### DIFF
--- a/Assets/UniCommon/Scripts/Async/Asyncs.cs
+++ b/Assets/UniCommon/Scripts/Async/Asyncs.cs
@@ -3,7 +3,7 @@ using UniRx;
 
 namespace UniCommon {
     public static class Asyncs {
-        public static UniRx.IObservable<bool> Execute(Action action) {
+        public static IObservable<bool> Execute(Action action) {
             return Execute(() => {
                 action();
                 return true;
@@ -19,7 +19,7 @@ namespace UniCommon {
             }
         }
 
-        public static UniRx.IObservable<T> Execute<T>(Func<T> task) {
+        public static IObservable<T> Execute<T>(Func<T> task) {
             return Observable.Create<T>(observer => {
                     try {
                         observer.OnNext(task());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unicommon",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Common Scripts for Unity3D",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
.NET 4.6でビルドできるようになった？